### PR TITLE
model's presence-settings -update

### DIFF
--- a/app/models/advance_payment.rb
+++ b/app/models/advance_payment.rb
@@ -2,6 +2,8 @@ class AdvancePayment < ApplicationRecord
   belongs_to :expense
   belongs_to :participant
 
+  validates :expense_id, presence: true
+  validates :participant_id, presence: true
   validates :participant_id, uniqueness: {scope: :expense_id, message: "は既選択済みです。"} 
   
 end

--- a/app/models/expense.rb
+++ b/app/models/expense.rb
@@ -5,7 +5,8 @@ class Expense < ApplicationRecord
   has_many :advance_payments, dependent: :destroy
   accepts_nested_attributes_for :advance_payments, allow_destroy: true
 
+  validates :trip_id, presense: true
   validates :title, presence: true, length: {maximum: 25, message: "は25字以内"}
   validates :amount, presence: true, numericality: {only_integer: true, greater_than: 0, less_than: 1_000_000 }
-  
+  validates :payer, presence: true
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -5,6 +5,7 @@ class Group < ApplicationRecord
   has_many :members, dependet: :destroy
   
 
+  validates :user_id, presence: true
   validates :name, presence: true, length: {maximum: 15, message: "は15字以内"}
   
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,6 +1,7 @@
 class Member < ApplicationRecord
   belongs_to :group
 
+  validates :group_id, presence: true
   validates :name, presence: true, length: {maximum: 12, message: "は12字以内"}
   validates :name, uniqueness: {scope: :group_id, message: "が既に存在します。"}
   

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -4,6 +4,7 @@ class Participant < ApplicationRecord
 
   has_many :advance_payments, dependent: :destroy
   
+  validates :trip_id, presence: true
   validates :name, presence: true, length: {maximum: 12, message: "は12字以内"}
   validates :name, uniqueness: {scope: :trip_id, message: "が既に存在します。"}
 

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -7,6 +7,8 @@ class Trip < ApplicationRecord
 
   enum settlement_status: {unsettled: 0, settled: 1}
 
+  validates :user_id, presence: true
   validates :titile, presence: true, length: {maximum: 20, message: "20字以内"}
+  validates :settlement_status, presence: true
 
 end

--- a/db/migrate/20250529142122_add_not_null_to_multiple_tables.rb
+++ b/db/migrate/20250529142122_add_not_null_to_multiple_tables.rb
@@ -1,0 +1,6 @@
+class AddNotNullToMultipleTables < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :participants, :name, false
+    change_column_null :groups, :name, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_28_232738) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_29_142122) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  # ---------------------------------------------------------------------
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -44,7 +42,19 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_28_232738) do
   end
 
   # ---------------------------------------------------------------------
-  
+
+  create_table "trips", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "title", null: false
+    t.integer "settlement_status", default: 0, null: false
+    t.date "departure_date", default: -> { "CURRENT_DATE" }, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "group_id"
+    t.index ["group_id"], name: "index_trips_on_group_id"
+    t.index ["user_id"], name: "index_trips_on_user_id"
+  end
+
   create_table "advance_payments", force: :cascade do |t|
     t.bigint "expense_id", null: false
     t.bigint "participant_id", null: false
@@ -69,9 +79,20 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_28_232738) do
     t.index ["trip_id"], name: "index_expenses_on_trip_id"
   end
 
+  create_table "participants", force: :cascade do |t|
+    t.bigint "trip_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["trip_id", "name"], name: "index_participants_on_trip_id_and_name", unique: true
+    t.index ["trip_id"], name: "index_participants_on_trip_id"
+  end
+
+  # ---------------------------------------------------------------------
+
   create_table "groups", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "name"
+    t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_groups_on_user_id"
@@ -86,26 +107,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_28_232738) do
     t.index ["group_id"], name: "index_members_on_group_id"
   end
 
-  create_table "participants", force: :cascade do |t|
-    t.bigint "trip_id", null: false
-    t.string "name"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["trip_id", "name"], name: "index_participants_on_trip_id_and_name", unique: true
-    t.index ["trip_id"], name: "index_participants_on_trip_id"
-  end
-
-  create_table "trips", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "title", null: false
-    t.integer "settlement_status", default: 0, null: false
-    t.date "departure_date", default: -> { "CURRENT_DATE" }, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "group_id"
-    t.index ["group_id"], name: "index_trips_on_group_id"
-    t.index ["user_id"], name: "index_trips_on_user_id"
-  end
+  # ---------------------------------------------------------------------
 
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
@@ -119,6 +121,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_28_232738) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  # ---------------------------------------------------------------------
 
   add_foreign_key "advance_payments", "expenses"
   add_foreign_key "advance_payments", "participants"


### PR DESCRIPTION
## 概要

dbに基づいて各モデル側のpresence: trueのバリデーション制約の追加
expenseとtripの日付についてはバリデーションをかけずにdb側でデフォルト値を保持