### PR TITLE
on-delete-restrict settings -update

### DIFF
--- a/db/migrate/20250529151329_add_ristrict_delete_to_multiple_tables.rb
+++ b/db/migrate/20250529151329_add_ristrict_delete_to_multiple_tables.rb
@@ -1,0 +1,9 @@
+class AddRistrictDeleteToMultipleTables < ActiveRecord::Migration[7.2]
+  def change
+    remove_foreign_key :expenses, column: :payer_id
+    remove_foreign_key :advance_payments, :participants
+
+    add_foreign_key :expenses, :participants, column: :payer_id, on_delete: :restrict
+    add_foreign_key :advance_payments, :participants, on_delete: :restrict
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_05_29_142122) do
+ActiveRecord::Schema[7.2].define(version: 2025_05_29_151329) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -41,20 +41,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_29_142122) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  # ---------------------------------------------------------------------
-
-  create_table "trips", force: :cascade do |t|
-    t.bigint "user_id", null: false
-    t.string "title", null: false
-    t.integer "settlement_status", default: 0, null: false
-    t.date "departure_date", default: -> { "CURRENT_DATE" }, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "group_id"
-    t.index ["group_id"], name: "index_trips_on_group_id"
-    t.index ["user_id"], name: "index_trips_on_user_id"
-  end
-
   create_table "advance_payments", force: :cascade do |t|
     t.bigint "expense_id", null: false
     t.bigint "participant_id", null: false
@@ -79,17 +65,6 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_29_142122) do
     t.index ["trip_id"], name: "index_expenses_on_trip_id"
   end
 
-  create_table "participants", force: :cascade do |t|
-    t.bigint "trip_id", null: false
-    t.string "name", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["trip_id", "name"], name: "index_participants_on_trip_id_and_name", unique: true
-    t.index ["trip_id"], name: "index_participants_on_trip_id"
-  end
-
-  # ---------------------------------------------------------------------
-
   create_table "groups", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "name", null: false
@@ -107,7 +82,26 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_29_142122) do
     t.index ["group_id"], name: "index_members_on_group_id"
   end
 
-  # ---------------------------------------------------------------------
+  create_table "participants", force: :cascade do |t|
+    t.bigint "trip_id", null: false
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["trip_id", "name"], name: "index_participants_on_trip_id_and_name", unique: true
+    t.index ["trip_id"], name: "index_participants_on_trip_id"
+  end
+
+  create_table "trips", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "title", null: false
+    t.integer "settlement_status", default: 0, null: false
+    t.date "departure_date", default: -> { "CURRENT_DATE" }, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "group_id"
+    t.index ["group_id"], name: "index_trips_on_group_id"
+    t.index ["user_id"], name: "index_trips_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
@@ -122,11 +116,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_29_142122) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  # ---------------------------------------------------------------------
-
   add_foreign_key "advance_payments", "expenses"
-  add_foreign_key "advance_payments", "participants"
-  add_foreign_key "expenses", "participants", column: "payer_id"
+  add_foreign_key "advance_payments", "participants", on_delete: :restrict
+  add_foreign_key "expenses", "participants", column: "payer_id", on_delete: :restrict
   add_foreign_key "expenses", "trips"
   add_foreign_key "groups", "users"
   add_foreign_key "members", "groups"


### PR DESCRIPTION
## 外部キー制約の追加 (`on_delete: :restrict`)

以下の外部キーに `on_delete: :restrict` を設定し、関連データが存在する場合に親レコード（参加者）が削除できないように制約を追加しました。

### 対象

1. `expenses` テーブルの `payer_id`
   - 参加者が **決済者** として紐付いた `expense` レコードが存在する場合、その参加者は削除できません。

2. `advance_payments` テーブルの `participant_id`
   - 参加者が **支払対象** として紐付いた `advance_payment` レコードが存在する場合、その参加者は削除できません。

### 目的

不整合なデータを防ぎ、参加者に紐づく重要な支出データが存在する状態で、誤って参加者レコードが削除されることを防止するため。
