### PR TITLE
restrict-w-error settings -update

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -1,8 +1,8 @@
 class Participant < ApplicationRecord
   belongs_to :trip
-  has_many :paid_expenses, class_name: 'Expense', dependent: :destroy, foregin_key: 'payer_id'
+  has_many :paid_expenses, class_name: 'Expense', dependent: :restrict_with_error, foreign_key: 'payer_id'
 
-  has_many :advance_payments, dependent: :destroy
+  has_many :advance_payments, dependent: :restrict_with_error
   
   validates :trip_id, presence: true
   validates :name, presence: true, length: {maximum: 12, message: "は12字以内"}


### PR DESCRIPTION
## Participantモデルのdependent設定を修正

### 概要

Participantモデルにおける関連レコードの削除時の挙動を見直しました。  
アプリケーションとDBの削除制御の方針を統一し、予期せぬエラーや不整合を防ぐための対応です。

### 修正内容

- `paid_expenses` に設定されていた `dependent: :destroy` を `:restrict_with_error` に変更
- `advance_payments` に対しても `dependent: :restrict_with_error` を適用

### 背景

関連テーブル（expenses、advance_payments）には、外部キー制約として `on_delete: :restrict` を設定しています。  
このため、Rails側で `dependent: :destroy` を指定していると、削除処理がDB側で拒否され、例外が発生するケースがありました。

モデル側も `:restrict_with_error` を明示することで、削除不能な状態を事前に検知でき、エラー理由をユーザーに伝えることが可能になります。
